### PR TITLE
Add 'Aug' to month constants in constants/index.ts

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,6 +6,7 @@ export const MONTHS = [
   "May",
   "Jun",
   "Jul",
+  "Aug",
   "Sep",
   "Oct",
   "Nov",


### PR DESCRIPTION
Fixed issue with the month list: Aug was missing, causing the clock to display Dec in month of Nov, and it will not show the month in Dec.